### PR TITLE
removes README.md which is mostly empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-codepoint-geocode-api
-=====================
-
-A geocoding API for UK postcodes, based on the Ordnance Survey codepoint


### PR DESCRIPTION
This repo has both a README.md file and README.rdoc file. The md file is
mostly empty but in github its presence overrides the README.rdoc so by
deleting we'll see the docs.

TODO: update the docs and resolve duplication with the wiki page