### PR TITLE
Update ERB syntax for Chef 13 compatibility

### DIFF
--- a/config/database.yml.erb
+++ b/config/database.yml.erb
@@ -9,7 +9,7 @@ common: &default
 <% @environments.each do |env, config| %>
 <%= env %>:
   <<: *default
-  database: <%= config.name %>
-  username: <%= config.username %>
-  password: <%= config.password %>
+  database: <%= config['name'] %>
+  username: <%= config['username'] %>
+  password: <%= config['password'] %>
 <% end %>


### PR DESCRIPTION
* for whatever reason config.name no longer works, but config['name'] does
* manually tested using chef cookbook kitchen test